### PR TITLE
Force TLS version 1.2 as minimum.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -152,6 +152,7 @@ func (s *Server) ListenAndServe() error {
 						break
 					}
 				}
+				hs.TLSConfig.MinVersion = 2
 				err = hs.ListenAndServeTLS(s.configHttp.CertFile, s.configHttp.CertKeyFile)
 			} else {
 				err = hs.ListenAndServe()


### PR DESCRIPTION
Clients have enquired about our site's support for SSL and TLS1.0 and TLS1.1 as a security risk.