### PR TITLE
Force TLS version 1.2 as minimum.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -153,7 +153,10 @@ func (s *Server) ListenAndServe() error {
 						break
 					}
 				}
-				hs.TLSConfig.MinVersion = tls.VersionTLS12
+				hs.TLSConfig = &tls.Config{
+					MinVersion:               tls.VersionTLS12,
+					PreferServerCipherSuites: true,
+				}
 				err = hs.ListenAndServeTLS(s.configHttp.CertFile, s.configHttp.CertKeyFile)
 			} else {
 				err = hs.ListenAndServe()

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"compress/gzip"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -152,6 +153,7 @@ func (s *Server) ListenAndServe() error {
 						break
 					}
 				}
+				hs.TLSConfig.MinVersion = tls.VersionTLS12
 				err = hs.ListenAndServeTLS(s.configHttp.CertFile, s.configHttp.CertKeyFile)
 			} else {
 				err = hs.ListenAndServe()


### PR DESCRIPTION
Clients have enquired about our site's support for SSL and TLS1.0 and TLS1.1 as a security risk.